### PR TITLE
[Feat/#6] 로그인 전역 상태 관리 및 로그아웃 기능 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
         "axios": "^1.8.4",
         "next": "15.2.4",
         "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react-dom": "^19.0.0",
+        "zustand": "^5.0.3"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -3273,7 +3274,7 @@
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.0.tgz",
       "integrity": "sha512-UaicktuQI+9UKyA4njtDOGBD/67t8YEBt2xdfqu8+gP9hqPUPsiXlNPcpS2gVdjmis5GKPG3fCxbQLVgxsQZ8w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -4509,7 +4510,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -8673,6 +8674,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.3.tgz",
+      "integrity": "sha512-14fwWQtU3pH4dE0dOpdMiWjddcH+QzKIgk1cl8epwSE7yag43k/AD/m4L6+K7DytAOr9gGBe3/EXj9g7cdostg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "axios": "^1.8.4",
     "next": "15.2.4",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "zustand": "^5.0.3"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -1,7 +1,9 @@
 // src/apis/auth.ts
 
 import instance from '@/libs/instance';
+import { useAuthStore } from '@/store/useAuthStore';
 
+// 소셜 로그인 토큰 발급
 export const exchangeToken = async (provider: string, code: string) => {
   const response = await instance.post(
     `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/${provider}/token`,
@@ -9,6 +11,20 @@ export const exchangeToken = async (provider: string, code: string) => {
       code: code || '',
     }
   );
+  console.log(response.data.data);
+  return response.data.data;
+};
 
+// 엑세스 토큰 재발급
+export const refreshAccessToken = async () => {
+  const response = await instance.post('/api/token/access', {
+    refreshToken: useAuthStore.getState().refreshToken,
+  });
+  return response.data;
+};
+
+// 로그아웃
+export const logout = async () => {
+  const response = await instance.post('/api/logout');
   return response.data;
 };

--- a/src/app/login/LoginPage.tsx
+++ b/src/app/login/LoginPage.tsx
@@ -2,6 +2,7 @@
 
 import { exchangeToken } from '@/apis/auth';
 import { SocialLoginButton } from '@/components/auth/SocialLoginButton';
+import { useAuthStore } from '@/store/useAuthStore';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useEffect } from 'react';
 
@@ -9,15 +10,20 @@ export default function Login() {
   const searchParams = useSearchParams();
   const router = useRouter();
   const code = searchParams.get('code');
-  const provider = localStorage.getItem('provider') || '';
+  let provider = '';
+
+  if (typeof window !== 'undefined') {
+    provider = localStorage.getItem('provider') || '';
+  }
 
   useEffect(() => {
     if (!code) return;
 
     const fetchToken = async () => {
       try {
-        const { token } = await exchangeToken(provider, code);
-        console.log(token); // 추후 전역 상태 관리할 때 변경 예정
+        const { accessToken, refreshToken } = await exchangeToken(provider, code);
+        useAuthStore.getState().setTokens({ accessToken, refreshToken });
+        console.log(accessToken, refreshToken);
         router.push('/');
       } catch (error) {
         console.error(error);

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,29 +1,30 @@
 // src/components/layout/Header.tsx
+import LoginButton from './LoginButton';
 
 import Link from 'next/link';
 
 export default function Header() {
   return (
-    <header className="w-full bg-white fixed top-0 left-0 z-999">
-      <div className="w-full px-8 py-4 flex justify-between items-center">
-        <div className="w-1/3 flex justify-between items-center">
+    <header className="fixed top-0 left-0 w-full bg-white z-999">
+      <div className="flex justify-between items-center px-8 py-4 w-full">
+        <div className="flex justify-between items-center w-1/3">
           <Link href="/" className="text-xl font-bold">
             SKHUni
           </Link>
           <nav className="flex gap-8">
-            <Link href="/about" className="px-2 py-1 hover:bg-gray-100 rounded-md">
+            <Link href="/about" className="px-2 py-1 rounded-md hover:bg-gray-100">
               About
             </Link>
-            <Link href="/projects" className="px-2 py-1 hover:bg-gray-100 rounded-md">
+            <Link href="/projects" className="px-2 py-1 rounded-md hover:bg-gray-100">
               Project
             </Link>
-            <Link href="/members" className="px-2 py-1 hover:bg-gray-100 rounded-md">
+            <Link href="/members" className="px-2 py-1 rounded-md hover:bg-gray-100">
               Member
             </Link>
           </nav>
         </div>
         <div className="flex items-center">
-          <Link href="/login">로그인/회원가입</Link>
+          <LoginButton />
         </div>
       </div>
     </header>

--- a/src/components/layout/LoginButton.tsx
+++ b/src/components/layout/LoginButton.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { useAuthStore } from '@/store/useAuthStore';
+import Link from 'next/link';
+import { useLogout } from '@/hooks/useLogout';
+import useIsMounted from '@/hooks/useIsMounted';
+
+export default function LoginButton() {
+  const isLoggedIn = useAuthStore((state) => state.isLoggedIn());
+  const { handleLogout } = useLogout();
+  const mounted = useIsMounted();
+
+  if (!mounted) return null;
+
+  return isLoggedIn ? (
+    <div className="flex gap-4">
+      <p>000님 안녕하세요!</p>
+      <button onClick={handleLogout}>로그아웃</button>
+    </div>
+  ) : (
+    <Link href="/login">로그인/회원가입</Link>
+  );
+}

--- a/src/hooks/useIsMounted.ts
+++ b/src/hooks/useIsMounted.ts
@@ -1,0 +1,11 @@
+import { useEffect, useState } from 'react';
+
+export default function useIsMounted() {
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  return mounted;
+}

--- a/src/hooks/useLogout.ts
+++ b/src/hooks/useLogout.ts
@@ -1,0 +1,22 @@
+// src/hooks/useLogout.ts
+import { logout } from '@/apis/auth';
+import { useAuthStore } from '@/store/useAuthStore';
+import { useRouter } from 'next/navigation';
+
+export const useLogout = () => {
+  const clearTokens = useAuthStore((state) => state.clearTokens);
+  const router = useRouter();
+
+  const handleLogout = async () => {
+    try {
+      await logout();
+    } catch (err) {
+      console.error('로그아웃 오류:', err);
+    } finally {
+      clearTokens();
+      router.replace('/');
+    }
+  };
+
+  return { handleLogout };
+};

--- a/src/libs/instance.ts
+++ b/src/libs/instance.ts
@@ -1,9 +1,24 @@
 // src/lib/instance.ts
+import { useAuthStore } from '@/store/useAuthStore';
 import axios from 'axios';
 
 const instance = axios.create({
   baseURL: process.env.NEXT_PUBLIC_API_BASE_URL,
   withCredentials: true,
 });
+
+// 요청 헤더에 엑세스 토큰 추가
+instance.interceptors.request.use(
+  (config) => {
+    const accessToken = useAuthStore.getState().accessToken;
+    if (accessToken) {
+      config.headers.Authorization = `Bearer ${accessToken}`;
+    }
+    return config;
+  },
+  (error) => {
+    return Promise.reject(error);
+  }
+);
 
 export default instance;

--- a/src/store/useAuthStore.ts
+++ b/src/store/useAuthStore.ts
@@ -1,0 +1,30 @@
+// src/store/useAuthStore.ts
+
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+interface AuthTokens {
+  accessToken: string | null;
+  refreshToken: string | null;
+}
+
+interface AuthState extends AuthTokens {
+  setTokens: (tokens: AuthTokens) => void;
+  clearTokens: () => void;
+  isLoggedIn: () => boolean;
+}
+
+export const useAuthStore = create<AuthState>()(
+  persist(
+    (set, get) => ({
+      accessToken: null,
+      refreshToken: null,
+      setTokens: ({ accessToken, refreshToken }) => set({ accessToken, refreshToken }),
+      clearTokens: () => set({ accessToken: null, refreshToken: null }),
+      isLoggedIn: () => get().accessToken !== null,
+    }),
+    {
+      name: 'auth-storage',
+    }
+  )
+);


### PR DESCRIPTION
## 🔥 Related Issues

- close #6 

## ⛅️ 작업 내용

- [x] 로그인 전역 상태 관리 구현
- [x] 로그아웃 api 연결
- [x] 유저 상태에 따라 헤더 상태 변경
- [x] 토큰 저장
- [x] bearer에 token 넣어주기
- [x] accessToken 만료 시 refreshToken으로 재발급하는 인터셉터 구현

