### PR TITLE
[Feat/#35] User QA 반영

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  reactStrictMode: false,
   images: {
     remotePatterns: [
       {

--- a/src/app/member/page.tsx
+++ b/src/app/member/page.tsx
@@ -7,8 +7,7 @@ export default function MembersPage() {
         <div className="flex flex-col gap-2">
           <h3 className="text-2xl font-bold">등록된 회대 멤버 목록</h3>
           <p className="text-sm text-gray-500">
-            성공회대 IT 커뮤니티 스쿠니에 등록된 멤버를 확인할 수 있습니다. <br />
-            멤버로 등록되지 않았다면, <b>로그인 후 재학생 인증</b>을 해주세요.
+            성공회대 IT 커뮤니티 스쿠니에 등록된 멤버를 확인할 수 있습니다.
           </p>
         </div>
         <MemberListPage />

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -45,12 +45,14 @@ export default function MyPage() {
   }, [role]);
 
   const handleDeleteProject = async (projectId: number) => {
-    try {
-      await deleteProject(projectId);
-      setProjects(projects.filter((project) => project.projectId !== projectId));
-      toast.success('프로젝트가 성공적으로 삭제되었습니다.');
-    } catch (error) {
-      console.error('프로젝트 삭제 실패:', error);
+    if (confirm('정말 삭제하시겠습니까?')) {
+      try {
+        await deleteProject(projectId);
+        setProjects(projects.filter((project) => project.projectId !== projectId));
+        toast.success('프로젝트가 성공적으로 삭제되었습니다.');
+      } catch (error) {
+        console.error('프로젝트 삭제 실패:', error);
+      }
     }
   };
 

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -11,7 +11,7 @@ import { deleteProject, getMyProjects } from '@/apis/projects';
 import { MyProjectCard } from '@/components/mypage/MyProjectCard';
 import { Project } from '@/types/projects';
 import { useRouter } from 'next/navigation';
-
+import toast from 'react-hot-toast';
 export default function MyPage() {
   const router = useRouter();
   const [isOpen, setIsOpen] = useState(false);
@@ -48,6 +48,7 @@ export default function MyPage() {
     try {
       await deleteProject(projectId);
       setProjects(projects.filter((project) => project.projectId !== projectId));
+      toast.success('프로젝트가 성공적으로 삭제되었습니다.');
     } catch (error) {
       console.error('프로젝트 삭제 실패:', error);
     }

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -4,8 +4,8 @@ import Image from 'next/image';
 export default function Footer() {
   return (
     <footer className="w-full bg-white">
-      <div className="flex justify-between items-center px-8 py-8 w-full">
-        <h3 className="text-base font-bold text-gray-800 md:text-2xl">
+      <div className="flex justify-between items-center px-4 py-4 w-full sm:px-8 sm:py-8">
+        <h3 className="text-sm font-bold text-gray-800 md:text-2xl">
           Fly your Ideas with your Colleagues
         </h3>
         <div className="flex gap-4">

--- a/src/components/main/MemberCardVertical.tsx
+++ b/src/components/main/MemberCardVertical.tsx
@@ -17,7 +17,7 @@ export const MemberCardVertical = ({ member }: { member: UserInfo }) => {
         <h3 className="text-xl font-bold">{member.name}</h3>
         <p className="text-sm text-gray-500">{FIELD_LABELS[member.fieldType] || '분야 미정'}</p>
         <h6 className="text-sm font-normal leading-none text-gray-700">
-          {member.studentId}학번 (
+          {member.studentId ? `${member.studentId}학번` : '학번 미정'} (
           {ENROLLMENT_STATUS_LABELS[member.enrollmentStatus ?? EnrollmentStatus.ENROLLED]})
         </h6>
       </div>

--- a/src/components/member/MemberCard.tsx
+++ b/src/components/member/MemberCard.tsx
@@ -16,7 +16,8 @@ export const MemberCard = ({ member }: MemberCardProps) => {
         width={100}
         height={100}
         style={{ width: '100px', height: '100px' }}
-        className="object-cover rounded-full"
+        className="object-cover rounded-full cursor-pointer hover:opacity-80"
+        onClick={() => router.push(`/member/${member.memberId}`)}
       />
       <div className="flex flex-col gap-2">
         <div className="flex gap-2 items-center">

--- a/src/components/member/MemberCard.tsx
+++ b/src/components/member/MemberCard.tsx
@@ -9,7 +9,7 @@ interface MemberCardProps {
 export const MemberCard = ({ member }: MemberCardProps) => {
   const router = useRouter();
   return (
-    <div className="flex gap-8 w-full">
+    <div className="flex gap-4 w-full sm:gap-8">
       <img
         src={member.picture}
         alt="profile"

--- a/src/components/member/MemberListPage.tsx
+++ b/src/components/member/MemberListPage.tsx
@@ -7,8 +7,10 @@ import { MemberFilterBar } from './filters/MemberFilterBar';
 import { getMemberList } from '@/apis/members';
 import { EnrollmentStatus, Field, MemberList } from '@/types/users';
 import LoadingSpinner from '../common/LoadingSpinner';
-
+import Link from 'next/link';
+import { useAuthStore } from '@/store/useAuthStore';
 export const MemberListPage = () => {
+  const { role } = useAuthStore();
   const [memberList, setMemberList] = useState<MemberList>({
     members: [],
     pageInfo: {
@@ -68,6 +70,20 @@ export const MemberListPage = () => {
 
   return (
     <div className="flex flex-col gap-8">
+      {role === 'ROLE_USER' && (
+        <div className="flex justify-between items-center px-3 py-6 sm:px-4 sm:py-3 text-sm text-gray-700 bg-[#F5F0E1] rounded-lg border border-[#F4C430] sm:flex-row flex-col gap-2">
+          <p>
+            아직 재학생 인증을 안하셨네요! <br />
+            재학생 인증하고 스쿠니 멤버에 함께해주세요!
+          </p>
+          <Link
+            href="/mypage"
+            className="ml-4 px-4 py-2 text-xs bg-[#512DA8] rounded-md hover:bg-[#3f2291]"
+          >
+            <span className="text-white">재학생 인증하러 가기</span>
+          </Link>
+        </div>
+      )}
       <MemberFilterBar filters={filters} setFilters={setFilters} />
       {isLoading ? (
         <div className="flex justify-center items-center h-[20rem]">

--- a/src/components/member/MemberListPage.tsx
+++ b/src/components/member/MemberListPage.tsx
@@ -58,7 +58,14 @@ export const MemberListPage = () => {
       setIsLoading(false);
     };
     fetchMemberList();
-  }, [filters]);
+  }, [
+    filters.page,
+    filters.name,
+    filters.field,
+    filters.enrollmentStatus,
+    filters.coffeeChat,
+    filters.codeReview,
+  ]);
 
   // 페이지 변경 시 filters.page 업데이트
   const handlePageChange = (page: number) => {

--- a/src/components/member/detail/MemberBasicInfo.tsx
+++ b/src/components/member/detail/MemberBasicInfo.tsx
@@ -7,8 +7,9 @@ import { useEffect, useRef, useState } from 'react';
 import { AbleBadge } from '@/components/common/AbleBadge';
 import { RequestModal } from './RequestModal';
 import { useAuthStore } from '@/store/useAuthStore';
-
+import { useRouter } from 'next/navigation';
 export default function MemberBasicInfo({ member }: { member: UserInfo }) {
+  const router = useRouter();
   const [isOpen, setIsOpen] = useState(false);
   const [selectedOption, setSelectedOption] = useState<'커피챗 요청' | '코드리뷰 요청' | null>(
     null
@@ -30,7 +31,8 @@ export default function MemberBasicInfo({ member }: { member: UserInfo }) {
 
   const handleSelect = (option: string) => {
     if (isGuest) {
-      alert('로그인 후 이용 가능해요.');
+      alert('로그인 후 이용 가능한 서비스입니다.');
+      router.push('/login');
       return;
     }
     if (

--- a/src/components/member/detail/MemberBasicInfo.tsx
+++ b/src/components/member/detail/MemberBasicInfo.tsx
@@ -113,7 +113,7 @@ export default function MemberBasicInfo({ member }: { member: UserInfo }) {
           </div>
         </div>
       </div>
-      <div className="relative" ref={dropdownRef}>
+      <div className="relative mt-4 sm:mt-0" ref={dropdownRef}>
         {!member.isMine && (
           <button
             type="button"

--- a/src/components/member/detail/MemberIntroduction.tsx
+++ b/src/components/member/detail/MemberIntroduction.tsx
@@ -7,7 +7,7 @@ interface MemberIntroductionProps {
 
 export const MemberIntroduction = ({ introduction }: MemberIntroductionProps) => {
   return (
-    <div>
+    <div className="pb-8">
       <MdPreview value={introduction || '소개글이 없습니다'} theme="light" language="ko-KR" />
     </div>
   );

--- a/src/components/member/detail/MemberProjects.tsx
+++ b/src/components/member/detail/MemberProjects.tsx
@@ -8,8 +8,7 @@ interface MemberProjectsProps {
 export const MemberProjects = ({ projects }: MemberProjectsProps) => {
   console.log(projects);
   return (
-    <div className="flex flex-col gap-4">
-      <h3 className="text-lg font-bold">프로젝트</h3>
+    <div className="flex flex-col gap-4 pb-8">
       <div className="grid grid-cols-1 gap-8 sm:grid-cols-2">
         {projects && projects.length > 0 ? (
           projects.map((project) => <MemberProject key={project.projectId} project={project} />)

--- a/src/components/verify/EmailStep.tsx
+++ b/src/components/verify/EmailStep.tsx
@@ -9,13 +9,17 @@ interface Props {
 export default function EmailStep({ email, setEmail, onSubmit, loading, error }: Props) {
   return (
     <div className="flex flex-col gap-6">
-      <input
-        type="email"
-        value={email}
-        onChange={(e) => setEmail(e.target.value)}
-        placeholder="학교 이메일을 입력하세요."
-        className="px-4 py-3 text-sm rounded-md border border-gray-300 leading-0 text-gray-700 outline-[#512DA8]"
-      />
+      <div className="flex gap-2 items-center">
+        <input
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="이메일 입력"
+          className="px-4 py-3 text-sm rounded-md border border-gray-300 leading-0 text-gray-700 outline-[#512DA8]"
+        />
+        <p className="text-lg text-gray-700">@office.skhu.ac.kr</p>
+      </div>
+
       {error && <p className="text-sm text-[#E53935]">{error}</p>}
       <button
         onClick={onSubmit}

--- a/src/components/verify/VerifyModal.tsx
+++ b/src/components/verify/VerifyModal.tsx
@@ -18,14 +18,11 @@ export default function VerifyModal({
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
 
+  // 코드 전송
   const handleSendCode = async () => {
-    if (!email.endsWith('@office.skhu.ac.kr')) {
-      setError('학교 이메일만 입력 가능합니다.');
-      return;
-    }
     try {
       setLoading(true);
-      await sendEmailCode(email);
+      await sendEmailCode(email + '@office.skhu.ac.kr');
       setStep('code');
       setError('');
     } catch {
@@ -35,6 +32,7 @@ export default function VerifyModal({
     }
   };
 
+  // 인증 확인
   const handleVerify = async () => {
     if (code.length !== 6) {
       setError('6자리 인증번호를 입력해주세요.');
@@ -42,7 +40,7 @@ export default function VerifyModal({
     }
     try {
       setLoading(true);
-      await checkEmailCode(email, code);
+      await checkEmailCode(email + '@office.skhu.ac.kr', code);
       onSuccess(); // 인증 완료 처리
       onClose(); // 모달 닫기
     } catch {


### PR DESCRIPTION
## 🔥 Related Issues

- close #35 

## ⛅️ 작업 내용

- [x] 재학생 첫 인증 시 메일 양식 고정 뷰 구현
- [x] 프로필 사진 눌렀을 때 링크 이동할 수 있도록 구현
- [x] 코드리뷰 및 커피챗 요청 시 비로그인 -> 로그인 해야 가능하다는 문구와 함께 로그인 페이지로 이동할 수 있도록 구현
- [x] (모바일 뷰) 자기소개 탭 내용과 푸터 간격 넓게 구현
- [x] 멤버 리스트에서 api가 두 번 요청되는 현상 수정
- [x] (모바일 뷰) Contact부분 margin주기
- [x] 재학생 인증 안했을 때 하러가라고 ToolTip 구현 (Member 권한과 함께)
- [x] 메인화면에서 학번 미입력시 학번 미정이라고 뜨도록 수정
- [x] 프로젝트 삭제 시 toast
- [x] (모바일 뷰) 멤버 리스트 뱃지 크기 생각
- [x] (모바일 뷰) 푸터 padding값 늘리기


